### PR TITLE
Update upstream DaskHub chart version

### DIFF
--- a/daskhub-azimuth/Chart.yaml
+++ b/daskhub-azimuth/Chart.yaml
@@ -7,7 +7,7 @@ icon: https://docs.dask.org/en/stable/_images/dask_horizontal.svg
 keywords: [dask, daskhub]
 dependencies:
   - name: daskhub
-    version: 2022.11.0
+    version: jh3.0.3-dg2023.9.0
     repository: https://helm.dask.org/
 
 annotations:


### PR DESCRIPTION
This should fix DaskHub deployments on k8s >= v1.27 but needs testing before merge.

Note: appVersion naming convention changed in upstream chart [here](https://github.com/dask/helm-chart/commit/e70b53a0246678dd34d0d72a44e7bb3cd51c2c20)