### PR TITLE
Configure Argo chart to uninstall CRDs

### DIFF
--- a/argocd-azimuth/values.yaml
+++ b/argocd-azimuth/values.yaml
@@ -8,3 +8,6 @@ argo-cd:
     params:
       server.insecure: true
       server.disable.auth: true
+  crds:
+    # CRDs should be uninstalled as part of Helm chart
+    keep: false


### PR DESCRIPTION
Since the Argo app installs it's CRDs on the target cluster, uninstalling the app then reinstalling with a different name leads to:
```
Unable to continue with install: CustomResourceDefinition "applications.argoproj.io" in namespace "" exists and cannot be imported into the current release: invalid ownership metadata; annotation validation error: key "meta.helm.sh/release-name" must equal "<old-release-name>": current value is "<new-release-name>";
```
this PR tells the Helm chart to remove the CRDs when the app is uninstalled which should fix the above bug.